### PR TITLE
change metrics endpoint to http so kube proxy can connect to it

### DIFF
--- a/stable/insights-chart/templates/policyreport-metrics-deployment.yaml
+++ b/stable/insights-chart/templates/policyreport-metrics-deployment.yaml
@@ -59,7 +59,7 @@ spec:
         imagePullPolicy: "{{ .Values.global.pullPolicy }}"
         args:
         - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8443/
+        - --upstream=http://127.0.0.1:8383/
         - --logtostderr=true
         - --v=10
         - "--tls-cert-file=/var/run/insights-metrics-certs/tls.crt"
@@ -85,22 +85,20 @@ spec:
         args:
         - --port=8383
         - --telemetry-port=8444
-        - "--tls-crt-file=/var/run/insights-metrics-certs/tls.crt"
-        - "--tls-key-file=/var/run/insights-metrics-certs/tls.key"
         resources:
 {{ toYaml .Values.insights.metrics.resources | indent 10 }}
         readinessProbe:
           httpGet:
             path: /healthz
             port: 8444
-            scheme: HTTPS
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 5
         livenessProbe:
           httpGet:
             path: /healthz
             port: 8444
-            scheme: HTTPS
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 5
         volumeMounts:

--- a/stable/insights-chart/templates/policyreport-metrics-deployment.yaml
+++ b/stable/insights-chart/templates/policyreport-metrics-deployment.yaml
@@ -84,6 +84,7 @@ spec:
             - ALL
         args:
         - --port=8383
+        - --host=127.0.0.1
         - --telemetry-port=8444
         resources:
 {{ toYaml .Values.insights.metrics.resources | indent 10 }}


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

Makes the metrics available via http so that the kube proxy can work. The proxy will still use https on the same port that the metrics were using previously, so the end result should be unchanged besides the fact that it will require authentication now.